### PR TITLE
fix 2 tests after capitalisation

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -334,7 +334,7 @@ def dirichlet_table():
 # should refactor this into WebDirichlet.py
 @characters_page.route("/Dirichlet/grouptable")
 def dirichlet_group_table(**args):
-    modulus = request.args.get("Modulus", 1, type=int)
+    modulus = request.args.get("modulus", 1, type=int)
     info = to_dict(args)
     if "modulus" not in info:
         info["modulus"] = modulus

--- a/lmfdb/test_homepage.py
+++ b/lmfdb/test_homepage.py
@@ -45,7 +45,7 @@ class HomePageTest(LmfdbTest):
         Check that the links in Box 3 work.
         """
         homepage = self.tc.get("/").data
-        self.check(homepage, "/L/", 'Holomorphic cusp form')
+        self.check(homepage, "/L/", 'Holomorphic Cusp Form')
         self.check(homepage, "/ModularForm/", r'Maass Forms on \(\GL(2,\Q) \)')
         self.check(homepage, "/EllipticCurve/Q/", 'curve, label or isogeny class label')
         self.check(homepage, "/NumberField/", 'x^7 - x^6 - 3 x^5 + x^4 + 4 x^3 - x^2 - x + 1')


### PR DESCRIPTION
These two changes fix the test failures.  They could both have been picked up if you had run the test suite locally before making the PR.  In one case the text of the newly capitalised title was being checked literally so the test just needed changing.  In the other case you had capitalised something which definitely should not have been.
If you merge this then your original PR will automatically update and set Travis on to testing again.