### PR TITLE
Fix hover and font spacing problem (for firefox) in tabs

### DIFF
--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -425,7 +425,7 @@ body > .debug {
 #content {
   margin-top: 10px;
   font-size: 95%;
-  line-height: 135%;
+  line-height: 1.4;
   padding-right: 10px;
 }
 
@@ -2336,24 +2336,29 @@ button.search_fresh {
   background: {{color.button_background}};
 }
 
-
+/* Tabs for elliptic curves & lattice pages */
 div.tab-container {
   display: inline-block;
   border-radius: 5px;
   overflow: hidden;
   font-weight: bold;
+  line-height: 1.4;
 }
 
-span.tab-active {
-  padding: 10px;
-  background: #0D47A1;
-  color: white;
+/* ">" selector is needed because a's are already styled above */
+span.tab-inactive > a {
+    color: inherit;
+    background: inherit;
 }
+
+span.tab-active, span.tab-inactive:hover {
+  padding: 10px;
+  background: {{ color.sidebar_background_h2_hover }};
+  color: {{ color.sidebar_h2_hover }};
+}
+
 span.tab-inactive {
   padding: 10px;
-  background: #90CAF9;
-}
-span.tab-inactive a, span.tab-inactive a:hover {
-  background: #90CAF9;
-  color: #0D47A1;
+  background: {{ color.sidebar_background_h2 }};
+  color: {{ color.col_sidebar_header_links }};
 }


### PR DESCRIPTION
There was some code for hovering there already, but it didn't work. Also, I updated it to use variables for colors, so color schemes work as intended.